### PR TITLE
Fix puppeteer freeze

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -12,6 +12,7 @@ const renderPdf = async ({
   emulateMedia,
 }) => {
   const browser = await puppeteer.launch({
+    args: ['--single-process'],
     defaultViewport: {
       width: 1200,
       height: 1000,


### PR DESCRIPTION
Resolves freeze on puppeteer render when running docsify-to-pdf. Based on https://github.com/kernoeb/docker-docsify-pdf/issues/7.